### PR TITLE
Add a test case for get_request_header

### DIFF
--- a/application/controllers/Set_header.php
+++ b/application/controllers/Set_header.php
@@ -1,0 +1,9 @@
+<?php
+
+class Set_header extends CI_Controller
+{
+  public function get_request_header()
+  {
+    echo $this->input->get_request_header('X-Request-Header', TRUE);
+  }
+}

--- a/application/tests/controllers/Set_header_test.php
+++ b/application/tests/controllers/Set_header_test.php
@@ -1,0 +1,20 @@
+<?php
+
+class Set_header_test extends TestCase
+{
+	public function test_get_header_value()
+	{
+    $header_value = 'header_value';
+    $this->request->setHeader('X-Request-Header', $header_value);
+		$output = $this->request('GET', 'set_header/get_request_header');
+    $this->assertEquals($header_value, $output);
+	}
+  
+  public function test_get_header_value_twice()
+  {
+    $header_value = 'header_value_2';
+    $this->request->setHeader('X-Request-Header', $header_value);
+    $output = $this->request('GET', 'set_header/get_request_header');
+    $this->assertEquals($header_value, $output);
+  }
+}


### PR DESCRIPTION
The test fails because the second invocation of get_request_header returns the value from the previous test.
