### PR TITLE
assertRedirect does not work with external redirects

### DIFF
--- a/application/controllers/Redirect.php
+++ b/application/controllers/Redirect.php
@@ -13,4 +13,16 @@ class Redirect extends CI_Controller
 		$this->load->helper('url');
 		redirect('/', 'refresh');
 	}
+
+	public function external()
+	{
+		$this->load->helper('url');
+		redirect('http://www.example.com');
+	}
+
+	public function refresh_external()
+	{
+		$this->load->helper('url');
+		redirect('http://www.example.com', 'refresh');
+	}
 }

--- a/application/tests/controllers/Redirect_test.php
+++ b/application/tests/controllers/Redirect_test.php
@@ -14,6 +14,12 @@ class Redirect_test extends TestCase
 		$this->assertRedirect('/', 302);
 	}
 
+	public function test_external_uri()
+	{
+		$this->request('GET', 'redirect/external');
+		$this->assertRedirect('http://www.example.com', 302);
+	}
+
 	public function test_refresh()
 	{
 		$this->request('GET', ['Redirect', 'refresh']);
@@ -24,5 +30,11 @@ class Redirect_test extends TestCase
 	{
 		$this->request('GET', 'redirect/refresh');
 		$this->assertRedirect('/', 200);
+	}
+
+	public function test_refresh_external_uri()
+	{
+		$this->request('GET', 'redirect/refresh_external');
+		$this->assertRedirect('http://www.example.com', 200);
 	}
 }


### PR DESCRIPTION
This is in conjunction with pull request #104 on ci-phpunit-test.

A controller with redirect('http://www.example.com') fails assertRedirect('http://www.example.com'), it's expecting something along the lines of http://localhost:8000/http://www.example.com.
