### PR TITLE
Ignore write cache file exception for root user(also for Windows).

### DIFF
--- a/application/tests/_tests/CIPHPUnitTestFileCache_test.php
+++ b/application/tests/_tests/CIPHPUnitTestFileCache_test.php
@@ -43,6 +43,11 @@ class CIPHPUnitTestFileCache_test extends PHPUnit_Framework_TestCase
 	{
 		chmod(__DIR__.'/tmp', 0);
 		$cache_file = __DIR__.'/tmp/cache_fail.php';
+		if(file_put_contents($cache_file, '') !== false)
+		{
+			unlink($cache_file);
+			$this->markTestSkipped('Ignored for root user');
+		}
 		@new CIPHPUnitTestFileCache($cache_file);
 	}
 
@@ -54,6 +59,12 @@ class CIPHPUnitTestFileCache_test extends PHPUnit_Framework_TestCase
 	{
 		chmod(__DIR__.'/tmp', 0);
 		$cache_file = __DIR__.'/tmp/sub/cache_fail.php';
+		$dir = dirname($cache_file);
+		if (@mkdir($dir, 0777, true) !== false)
+		{
+			rmdir($dir);
+			$this->markTestSkipped('Ignored for root user');
+		}
 		@new CIPHPUnitTestFileCache($cache_file);
 	}
 


### PR DESCRIPTION
I get the following messages while running unittest with root user.

```
There were 2 failures:

1) CIPHPUnitTestFileCache_test::test_construct_fail_to_create_cache_file
Failed asserting that exception of type "RuntimeException" is thrown.

/root/testgit/ci-app-for-ci-phpunit-test/vendor/phpunit/phpunit/phpunit:47

2) CIPHPUnitTestFileCache_test::test_construct_fail_to_create_dir
Failed asserting that exception of type "RuntimeException" is thrown.

/root/testgit/ci-app-for-ci-phpunit-test/vendor/phpunit/phpunit/phpunit:47
```

I tried to use "is_really_writable" at the beginning for checking([see here](https://github.com/kenjis/ci-app-for-ci-phpunit-test/commit/1fb297274139a93cfc17d23a87f2d632a737b4a5)) but it also failed.

I got the same result even with the following code, "is_writable" returns false with root user when running with phpunit. 

```
        public function test_construct_fail_to_create_cache_file()
        {
                chmod(__DIR__.'/tmp', 0);
                clearstatcache();
                if(is_writable(__DIR__.'/tmp'))
                {
                        $this->markTestSkipped('Ignored for root user');
                }
                $cache_file = __DIR__.'/tmp/cache_fail.php';
                @new CIPHPUnitTestFileCache($cache_file);
        }
```

However, it works well with the following code put in a single file being executed with php command-line.

```
<?php
function test_construct_fail_to_create_cache_file()
{
        if( ! file_exists(__DIR__.'/tmp'))
        {
                mkdir(__DIR__.'/tmp', 0777, true);
        }
        chmod(__DIR__.'/tmp', 0777);
        clearstatcache();
        var_dump(is_writable(__DIR__.'/tmp'));
        chmod(__DIR__.'/tmp', 0);
        clearstatcache();
        var_dump(is_writable(__DIR__.'/tmp'));
}
test_construct_fail_to_create_cache_file();
```

The output is

```
bool(true)
bool(false)
```

with non-root user , and is

```
bool(true)
bool(true)
```

with root user.

 Could you help to test it in case of my wrong configuration ?

Signed-off-by: tianhe1986 w1s2j3229@163.com
