### PR TITLE
add resetInstance test case

### DIFF
--- a/application/tests/_tests/CIPHPUnitTestDbTestCase_test.php
+++ b/application/tests/_tests/CIPHPUnitTestDbTestCase_test.php
@@ -59,4 +59,10 @@ class CIPHPUnitTestDbTestCase_test extends DbTestCase
 		$name = $this->grabFromDatabase($this->table, 'name', ['id' => 2]);
 		$this->assertEquals('CD', $name);
 	}
+
+	public function test_resetInstance_after_take_over_db()
+	{
+		$this->resetInstance();
+		$this->assertNotFalse($this->db->conn_id);
+	}
 }


### PR DESCRIPTION
An error occurred when I ran the following code.

```php
<?php
class Sample_model_test extends DbTestCase
{
   private $obj;

    public function setUp()
    {
        parent::setUp();
        $this->obj = $this->newModel('sample_model');
    }

    public function test_sample_insert()
    {
        $this->obj->add_sample('john');
        $this->grabFromDatabase('sample', ['name' => 'john']);
    }
}
```

following error message.

```shell
Error: Call to a member function real_escape_string() on boolean

/vagrant/vendor/codeigniter/framework/system/database/drivers/mysqli/mysqli_driver.php:391
/vagrant/vendor/codeigniter/framework/system/database/DB_driver.php:1143
/vagrant/vendor/codeigniter/framework/system/database/DB_driver.php:1108
/vagrant/vendor/codeigniter/framework/system/database/DB_query_builder.php:683
/vagrant/vendor/codeigniter/framework/system/database/DB_query_builder.php:623
/vagrant/vendor/kenjis/ci-phpunit-test/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php:109
```

This is to close the DB that the CI Instance has when calling `resetInstance`.

ci-phpunit-test PR: 
https://github.com/kenjis/ci-phpunit-test/pull/225